### PR TITLE
N+어치

### DIFF
--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -16,6 +16,6 @@ definitions:
 metadata:
   type: composite
 details: |-
-  ## Spacing {#spacing}
+  # Spacing {#spacing}
 
   Native speakers don't always follow proper spacing rules and may sometimes leave out the space turning it into <f>N어치</f>

--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -5,13 +5,13 @@ definitions:
     english_alternatives:
     meaning: Used to mean the amount that corresponds to that price
     examples:
-      - sentence: 이것 30우로 <f>어치만</f> 살 수 있어요?
+      - sentence: 그 가게에서 책 20,000<f>원어치를</f> 샀어요.
         type: simple
-        translated: Can I have 30 euros worth of this?
+        translated: I bought 20,000 won worth of books at that store.
         audio_url:
-      - sentence: 잃어버린 휴대폰는 수억 원 <f>어치이다</f>.
+      - sentence: 내가 시장에서 산 사과는 1,000<f>원어치예요</f>.
         type: simple
-        translated: The lost phones cost hundreds of millions of won.
+        translated: The apples I bought at the market are worth 1,000 won.
         audio_url:
 metadata:
   type: composite

--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -16,6 +16,6 @@ definitions:
 metadata:
   type: composite
 details: |-
-  # Spacing {#spacing}
+  # Similar looking forms {#similar-looking-forms}
 
-  Native speakers don't always follow proper spacing rules and may sometimes leave out the space turning it into <f>N어치</f>
+  There is another form :grammar[noun_짜리] which might look similar, but has a different usage.

--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -9,9 +9,9 @@ definitions:
         type: simple
         translated: I bought 20,000 won worth of books at that store.
         audio_url:
-      - sentence: 내가 시장에서 산 사과는 1,000<f>원어치예요</f>.
+      - sentence: 그의 경험은 매우 <f>값어치</f> 있는 것이었다.
         type: simple
-        translated: The apples I bought at the market are worth 1,000 won.
+        translated: His experience was very valuable.
         audio_url:
 metadata:
   type: composite

--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -1,0 +1,21 @@
+name: 어치
+definitions:
+  - slug: amount-that-corresponds-to-price
+    name: Amount that corresponds to that price
+    english_alternatives:
+    meaning: Used to mean the amount that corresponds to that price
+    examples:
+      - sentence: 이것 30우로 <f>어치만</f> 살 수 있어요?
+        type: simple
+        translated: Can I have 30 euros worth of this?
+        audio_url:
+      - sentence: 잃어버린 휴대폰는 수억 원 <f>어치이다</f>.
+        type: simple
+        translated: The lost phones cost hundreds of millions of won.
+        audio_url:
+metadata:
+  type: composite
+details: |-
+  ## Spacing {#spacing}
+
+  Native speakers don't always follow proper spacing rules and may sometimes leave out the space turning it into <f>N어치</f>

--- a/point/어치.yaml
+++ b/point/어치.yaml
@@ -16,6 +16,3 @@ definitions:
 metadata:
   type: composite
 details: |-
-  # Similar looking forms {#similar-looking-forms}
-
-  There is another form :grammar[noun_짜리] which might look similar, but has a different usage.


### PR DESCRIPTION
Used Naver Dictionary as a [source](https://korean.dict.naver.com/koendict/#/entry/koen/7ece5f972fe249bfa24274ad982768f5). Accorrding to Naver Dictionary it should be NOUN <space> 어치 but I added something about spacing, because it seems like that also happens.