### PR TITLE
Added additional definition to verb_자 and updated relation.yaml. New grammar pages: N-(으)로서, V-고 말다, V-고 말겠다, V-(으)ㅁ, V-거늘, N-(이)자.

### DIFF
--- a/point/noun_로서_으로서.yaml
+++ b/point/noun_로서_으로서.yaml
@@ -1,0 +1,39 @@
+name: (으)로서
+definitions:
+  - slug: role-capacity
+    name: Role or Capacity
+    english_alternatives: as, in the capacity of
+    meaning: Indicates the role, capacity, or status of someone or something in relation to an action or state.
+    examples:
+      - sentence: 학생<f>으로서</f> 책임을 다해야 합니다.
+        type: simple
+        translated: You must fulfill your responsibilities **as a student**.
+        audio_url: 
+      - sentence: 부모<f>로서</f> 최선을 다하고 있습니다.
+        type: simple
+        translated: I am doing my best **as a parent**.
+        audio_url: 
+      - sentence: 대표<f>로서</f> 회의에 참석했습니다.
+        type: simple
+        translated: He attended the meeting **as a representative**.
+        audio_url: 
+      - sentence: 비서<f>로서</f> 저는 정확한 정보를 제공합니다.
+        type: simple
+        translated: **As a secretary**, I provide accurate information.
+        audio_url: 
+      - sentence: 친구<f>로서</f> 너를 도와주고 싶어.
+        type: simple
+        translated: I want to help you **as a friend**.
+        audio_url: 
+      - sentence: 동료<f>로서</f> 조언을 해줄게.
+        type: simple
+        translated: I'll give you advice **as a colleague**.
+        audio_url: 
+metadata:
+  type: noun
+details: |-
+  # Role or Capacity {#role-capacity}
+
+  **N-(으)로서** is a particle used to indicate the role, capacity, or status of someone or something in relation to an action or state. It is translated as **"as"** or **"in the capacity of"**.
+  
+  **Note:** Do not confuse **N-(으)로서** with :grammar[noun_로써_으로써]{means-or-method}, which indicates means or method.

--- a/point/noun_이_자.yaml
+++ b/point/noun_이_자.yaml
@@ -3,7 +3,7 @@ definitions:
   - slug: dual-roles
     name: Indicating Dual Roles
     english_alternatives: both... and..., as well as
-    meaning: Used to indicate that someone or something is both A and B simultaneously.
+    meaning: Indicate that someone or something is both A and B simultaneously.
     examples:
       - sentence: 그는 나의 선생님<f>이자</f> 친구이다.
         type: simple
@@ -25,12 +25,29 @@ definitions:
         type: simple
         translated: This place is both a tourist spot and a historical site.
         audio_url: 
+  - slug: first-and-last
+    name: First and Last
+    english_alternatives: the first and the last
+    meaning: Emphasize that someone or something is both the first and the last
+    examples:
+      - sentence: 그 사람은 우리 나라의 처음<f>이자</f> 마지막 공주였어요.
+        type: simple
+        translated: That person was our country''s first and last princess.
+        audio_url: 
+      - sentence: 이 경기는 그의 처음<f>이자</f> 마지막 출전이었다.
+        type: simple
+        translated: This match was his first and last appearance.
+        audio_url: 
+      - sentence: 이것은 제 처음<f>이자</f> 마지막 기회예요.
+        type: simple
+        translated: This is my first and last chance.
+        audio_url: 
 metadata:
   type: noun
 details: |-
   # Usage {#usage}
 
- - When the word ends with a consonant, add <f>이자</f> after the word.
+  - When the word ends with a consonant, add <f>이자</f> after the word.
     - Example: 학생 → 학생<f>이자</f>
   
   - When the word ends with a vowel, add <f>자</f> after the word.

--- a/point/noun_이_자.yaml
+++ b/point/noun_이_자.yaml
@@ -1,0 +1,44 @@
+name: (이)자
+definitions:
+  - slug: dual-roles
+    name: Indicating Dual Roles
+    english_alternatives: both... and..., as well as
+    meaning: Used to indicate that someone or something is both A and B simultaneously.
+    examples:
+      - sentence: 그는 나의 선생님<f>이자</f> 친구이다.
+        type: simple
+        translated: He is both my teacher and friend.
+        audio_url: 
+      - sentence: 그녀는 배우<f>이자</f> 가수이다.
+        type: simple
+        translated: She is both an actress and a singer.
+        audio_url: 
+      - sentence: 이 책은 교과서<f>이자</f> 참고서입니다.
+        type: simple
+        translated: This book is both a textbook and a reference book.
+        audio_url: 
+      - sentence: 슬기님은 프로그래머<f>이자</f> 여성입니다.
+        type: simple
+        translated: Seulgi is a programmar as well as a woman.
+        audio_url: 
+      - sentence: 이곳은 관광지<f>이자</f> 역사적인 장소입니다.
+        type: simple
+        translated: This place is both a tourist spot and a historical site.
+        audio_url: 
+metadata:
+  type: noun
+details: |-
+  # Usage {#usage}
+
+ - When the word ends with a consonant, add <f>이자</f> after the word.
+    - Example: 학생 → 학생<f>이자</f>
+  
+  - When the word ends with a vowel, add <f>자</f> after the word.
+    - Example: 배우 → 배우<f>자</f>
+
+
+  **Notes:**
+
+  - Commonly used in both spoken and written Korean.
+  - **N(이)자** Connects two nouns to indicate dual roles or characteristics.
+  - Emphasizes that both **Noun1** + **Noun2** are equally important.

--- a/point/verb_거늘.yaml
+++ b/point/verb_거늘.yaml
@@ -1,0 +1,27 @@
+name: 거늘
+definitions:
+  - slug: reason-or-cause
+    name: Reason or Cause
+    english_alternatives: considering that, since, even though
+    meaning: Used to express a reason or cause, often implying a contrast or rhetorical question.
+    examples:
+      - sentence: 그는 열심히 노력했<f>거늘</f> 왜 실패했을까?
+        type: simple
+        translated: Considering that he worked hard, why did he fail?
+        audio_url: 
+      - sentence: 봄이 되었<f>거늘</f> 날씨가 아직도 춥다.
+        type: simple
+        translated: Even though it's spring, the weather is still cold.
+        audio_url: 
+      - sentence: 경고를 받았<f>거늘</f> 또 같은 실수를 하다니.
+        type: simple
+        translated: Considering that you were warned, you made the same mistake again.
+        audio_url: 
+metadata:
+  type: verb
+details: |-
+  # Usage {#usage}
+
+  - **V-거늘** is primarily used in literary, formal, or poetic contexts and is considered archaic in modern spoken Korean, so the examples should be treated as references rather than common usages in modern conversation.
+  - It often sets up a contrast between the expected outcome and the actual situation.
+  - Commonly used in proverbs or traditional expressions.

--- a/point/verb_고_말겠다.yaml
+++ b/point/verb_고_말겠다.yaml
@@ -18,7 +18,7 @@ definitions:
         translated: I will achieve my goal.
         audio_url:
 metadata:
-  type: composite
+  type: verb
 details: |-
   # Usage {#strong-determination}
 

--- a/point/verb_고_말겠다.yaml
+++ b/point/verb_고_말겠다.yaml
@@ -3,7 +3,7 @@ definitions:
   - slug: strong-determination
     name: Strong Determination
     english_alternatives: will definitely, won't stop until
-    meaning: Expresses the speaker's strong will or determination to do something.
+    meaning: Expresses the speaker''s strong will or determination to do something or complete an action.
     examples:
       - sentence: 이번 프로젝트를 성공시키<f>고 말겠습니다</f>.
         type: simple
@@ -20,6 +20,3 @@ definitions:
 metadata:
   type: verb
 details: |-
-  # Usage {#strong-determination}
-
-  **V-고 말겠다** is used to express strong determination or resolve to complete an action.

--- a/point/verb_고_말겠다.yaml
+++ b/point/verb_고_말겠다.yaml
@@ -1,0 +1,25 @@
+name: 고 말겠다
+definitions:
+  - slug: strong-determination
+    name: Strong Determination
+    english_alternatives: will definitely, won't stop until
+    meaning: Expresses the speaker's strong will or determination to do something.
+    examples:
+      - sentence: 이번 프로젝트를 성공시키<f>고 말겠습니다</f>.
+        type: simple
+        translated: I will definitely make this project a success.
+        audio_url:
+      - sentence: 반드시 진실을 밝히<f>고 말겠어요</f>.
+        type: simple
+        translated: I will uncover the truth no matter what.
+        audio_url:
+      - sentence: 목표를 이루<f>고 말겠다</f>.
+        type: simple
+        translated: I will achieve my goal.
+        audio_url:
+metadata:
+  type: composite
+details: |-
+  # Usage {#strong-determination}
+
+  **V-고 말겠다** is used to express strong determination or resolve to complete an action.

--- a/point/verb_고_말다.yaml
+++ b/point/verb_고_말다.yaml
@@ -1,0 +1,32 @@
+name: 고 말다
+definitions:
+  - slug: unintentional-result
+    name: Unintentional or Inevitable Result
+    english_alternatives: ended up, finally did
+    meaning: Expresses that an action happened unintentionally, unexpectedly, or inevitably.
+    examples:
+      - sentence: 그만 화를 내<f>고 말았어요</f>.
+        type: simple
+        translated: I ended up losing my temper.
+        audio_url:
+      - sentence: 친구의 비밀을 말하<f>고 말았습니다</f>.
+        type: simple
+        translated: I ended up telling my friend's secret.
+        audio_url:
+      - sentence: 다이어트 중인데 케이크를 먹<f>고 말았어</f>.
+        type: simple
+        translated: I was on a diet, but I ended up eating cake.
+        audio_url:
+metadata:
+  type: composite
+details: |-
+  # Unintentional or Inevitable Result {#unintentional-result}
+
+  **V-고 말다** is used to express that something happened:
+
+  - **Unintentionally or Unexpectedly:** The action was not planned or desired.
+  - **Inevitably:** Despite efforts to prevent it, the action occurred.
+  - **With Regret or Frustration:** Often conveys the speaker's disappointment.
+  
+
+  **Note:** When used in the future tense, :grammar[verb_고_말겠다]{strong-determination} shows the speaker's strong will or determination.

--- a/point/verb_고_말다.yaml
+++ b/point/verb_고_말다.yaml
@@ -18,7 +18,7 @@ definitions:
         translated: I was on a diet, but I ended up eating cake.
         audio_url:
 metadata:
-  type: composite
+  type: verb
 details: |-
   # Unintentional or Inevitable Result {#unintentional-result}
 

--- a/point/verb_으ㅁ.yaml
+++ b/point/verb_으ㅁ.yaml
@@ -1,0 +1,57 @@
+name: (으)ㅁ
+definitions:
+  - slug: concept-noun
+    name: Concept Noun
+    english_alternatives: the act of, the state of
+    meaning: Turns verbs or adjectives into abstract nouns representing a concept or idea.
+    examples:
+      - sentence: 죽<f>음</f>이 두렵다.
+        type: simple
+        translated: Death is frightening.
+        audio_url: 
+      - sentence: 믿<f>음</f>은 중요한 가치이다.
+        type: simple
+        translated: Faith is an important value.
+        audio_url: 
+      - sentence: 잠이 부족하면 건강에 해로<f>움</f>이 생긴다.
+        type: simple
+        translated: Lack of sleep causes harm to health.
+        audio_url: 
+  - slug: nominalization
+    name: Nominalization
+    english_alternatives: -ing, the act of
+    meaning: Turns verbs or adjectives into nouns, often used in formal writing to state facts or make lists.
+    examples:
+      - sentence: 공부하<f>ㅁ</f>이 즐겁다.
+        type: simple
+        translated: Studying is enjoyable.
+        audio_url: 
+      - sentence: 참석하지 못했<f>음</f>을 알려드립니다.
+        type: simple
+        translated: I inform you that I couldn't attend.
+        audio_url: 
+      - sentence: 문제를 해결했<f>음</f>을 보고합니다.
+        type: simple
+        translated: I report that the problem has been solved.
+        audio_url: 
+  - slug: formal-ending
+    name: Formal Sentence Ending
+    english_alternatives: (indicates statement)
+    meaning: Used at the end of sentences in formal writing to state facts or conclusions.
+    examples:
+      - sentence: 이상으로 보고를 마치겠<f>음</f>.
+        type: simple
+        translated: I will conclude the report here.
+        audio_url: 
+      - sentence: 모든 준비가 완료되었<f>음</f>.
+        type: simple
+        translated: All preparations have been completed.
+        audio_url: 
+metadata:
+  type: verb
+details: |-
+  # Usage {#usage}
+  
+  - Commonly used in **formal writing**, such as books, reports, notices, and official documents.
+  - Often used to **state facts** or **summarize information**.
+  - Can function as a sentence ending in formal contexts to state facts or conclusions.

--- a/point/verb_자.yaml
+++ b/point/verb_자.yaml
@@ -44,4 +44,4 @@ details: |-
 
   :grammar[verb_자]{simultaneous-action} indicates that the second action happens **as** or **when** the first action is occurring. Unlike :grammar[verb_자마자]{as-soon-as}, which emphasizes that the second action happens **immediately after** the first, **-자** in this usage conveys that the two actions are closely connected in time, often overlapping.
 
-  **Note:** This usage of **-자** is more common in written or formal contexts and is less frequently used in spoken Korean. In conversational Korean, :grammar[verb_으니까_니까]{reason-or-cause} or :grammar[verb_아서_어서_해서]{reason-or-clause} might be used instead.
+  **Note:** This usage of **-자** is more common in written or formal contexts and is less frequently used in spoken Korean. In conversational Korean, :grammar[verb_으니까_니까]{reason-or-cause} or :grammar[verb_아서_어서_해서]{reason-or-cause} might be used instead.

--- a/point/verb_자.yaml
+++ b/point/verb_자.yaml
@@ -42,6 +42,6 @@ details: |-
 
   # Simultaneous Action {#simultaneous-action}
 
-  :grammar[verb_자]{simultaneous-action} indicates that the second action happens **as** or **when** the first action is occurring. Unlike :grammar[verb_자마자]{as-soon-as}, which emphasizes that the second action happens **immediately after** the first, **-자** in this usage conveys that the two actions are closely connected in time, often overlapping.
+  :grammar[verb_자]{simultaneous-action} indicates that the second action happens **as** or **when** the first action is occurring. Unlike :grammar[verb_자마자]{as-soon-as}, which emphasizes that the second action happens **immediately after** the first, **V-자** in this usage conveys that the two actions are closely connected in time, often overlapping.
 
-  **Note:** This usage of **-자** is more common in written or formal contexts and is less frequently used in spoken Korean. In conversational Korean, :grammar[verb_으니까_니까]{reason-or-cause} or :grammar[verb_아서_어서_해서]{reason-or-cause} might be used instead.
+  **Note:** This usage of **V-자** is more common in written or formal contexts and is less frequently used in spoken Korean. In conversational Korean, :grammar[verb_으니까_니까]{reason-or-cause} or :grammar[verb_아서_어서_해서]{reason-or-cause} might be used instead.

--- a/point/verb_자.yaml
+++ b/point/verb_자.yaml
@@ -13,9 +13,35 @@ definitions:
         type: simple
         translated: Let's have a drink after work.
         audio_url: https://r2.kimchi-reader.app/grammar/회사_끝나면_술_한_잔_하자__2024-04-13.mp3
+
+  - slug: simultaneous-action
+    name: Simultaneous Action
+    english_alternatives: as, when, while
+    meaning: Indicates that the second action occurs **as** or **when** the first action is happening.
+    examples:
+      - sentence: 창문을 열<f>자</f> 바람이 들어왔다.
+        type: simple
+        translated: As I opened the window, the wind came in.
+        audio_url: 
+      - sentence: 의자에 앉<f>자</f> 잠들었다.
+        type: simple
+        translated: I fell asleep as I sat down.
+        audio_url: 
+      - sentence: 차에서 연기가 나<f>자</f> 운전사는 차에서 뛰쳐나왔다.
+        type: simple
+        translated: The driver rushed out of the car as smoke started coming out of it.
+        audio_url: 
+
 metadata:
   type: verb
-details: |-
-  # Formal language {#formal}
 
-  :grammar[verb_자]{suggestion} is a bit informal, the more formal version of this expression would be :grammar[verb_읍시다_ㅂ시다]{suggestion}.
+details: |-
+  # Suggestion {#suggestion}
+
+  :grammar[verb_자]{suggestion} is used to make informal suggestions to do something together. The more formal version of this expression is :grammar[verb_읍시다_ㅂ시다]{suggestion}.
+
+  # Simultaneous Action {#simultaneous-action}
+
+  :grammar[verb_자]{simultaneous-action} indicates that the second action happens **as** or **when** the first action is occurring. Unlike :grammar[verb_자마자]{as-soon-as}, which emphasizes that the second action happens **immediately after** the first, **-자** in this usage conveys that the two actions are closely connected in time, often overlapping.
+
+  **Note:** This usage of **-자** is more common in written or formal contexts and is less frequently used in spoken Korean. In conversational Korean, :grammar[verb_으니까_니까]{reason-or-cause} or :grammar[verb_아서_어서_해서]{reason-or-clause} might be used instead.

--- a/relation.yaml
+++ b/relation.yaml
@@ -33,3 +33,6 @@ relation:
   - concern:
       - { id: "noun_이야", slug: "copula" }
       - { id: "noun_이다", slug: "copula" }
+  - concern:
+      - { id: "verb_자", slug: "simultaneous-action" }
+      - { id: "verb_자마자", slug: "as-soon-as" }


### PR DESCRIPTION
Changes Made:

Added "Simultaneous Action" Definition to verb_자.yaml:

Purpose: To explain the usage of -자 when indicating that the second action occurs as or when the first action is happening.

Details:

1. Under the definitions section, added a new entry with the slug simultaneous-action and the name "Simultaneous Action".

2. Meaning: Clarified that this usage of -자 indicates actions occurring simultaneously or overlapping in time.

3. In the Details section added information for the distinction between -자 (Simultaneous Action) and -자마자 (As Soon As).

3. Notes on the usage of -자 in written/formal contexts, mentioned conversational alternatives like -으니까 and -아서/어서.

4. Updated relation.yaml to reflect new definition.