### PR TITLE
adds archaic grammar point -(으)리오

### DIFF
--- a/point/verb_으_리오.yaml
+++ b/point/verb_으_리오.yaml
@@ -2,7 +2,7 @@ name: -(으)리오
 definitions:
   - slug: expressing-impossibility
     name: Expressing Impossibility
-    english_alternatives: how could..., who would...
+    english_alternatives: how could, who would
     meaning: Emphasize that something is impossible or unlikely by asking a rhetorical question.
     examples:
       - type: simple

--- a/point/verb_으_리오.yaml
+++ b/point/verb_으_리오.yaml
@@ -17,6 +17,9 @@ definitions:
         sentence: 우리가 어찌 포기하였<f>으리오</f>.
         translated: How could we have given up?
         audio_url:
+      - type: simple
+        sentence: 그가 성공하겠<f>으리오</f>?.
+        translated: Could he possibly succeed?
 metadata:
   type: verb
 details: |-

--- a/point/verb_으_리오.yaml
+++ b/point/verb_으_리오.yaml
@@ -1,0 +1,22 @@
+name: -(으)리오
+definitions:
+  - slug: expressing-impossibility
+    name: Expressing Impossibility
+    english_alternatives: how could..., who would...
+    meaning: Emphasize that something is impossible or unlikely by asking a rhetorical question.
+    examples:
+      - type: simple
+        sentence: 내 어찌 고향을 잊<f>으리오</f>.
+        translated: How could I forget my home?
+        audio_url:
+      - type: simple
+        sentence: 그 누가 당신을 싫어하<f>리오</f>.
+        translated: Who would hate you?
+        audio_url:
+      - type: simple
+        sentence: 우리가 어찌 포기하였<f>으리오</f>.
+        translated: How could we have given up?
+        audio_url:
+metadata:
+  type: verb
+details: |-

--- a/point/verb_으_리오.yaml
+++ b/point/verb_으_리오.yaml
@@ -18,7 +18,7 @@ definitions:
         translated: How could we have given up?
         audio_url:
       - type: simple
-        sentence: 그가 성공하겠<f>으리오</f>?.
+        sentence: 그가 성공하겠<f>으리오</f>?
         translated: Could he possibly succeed?
 metadata:
   type: verb

--- a/point/verb_으_리오.yaml
+++ b/point/verb_으_리오.yaml
@@ -1,4 +1,4 @@
-name: -(으)리오
+name: (으)리오
 definitions:
   - slug: expressing-impossibility
     name: Expressing Impossibility


### PR DESCRIPTION
1. `-(으)리오`  can also be found in the combination: `-으오` + `리오` in archaic texts for politeness.

2. Unsure wether to call it `Expressing Impossibility` or `Expressing Supposition`. Latter one would be more aligned with other grammar pages like `[-겠-](https://kimchi-reader.app/grammar/verb_%EA%B2%A0#supposition)`