### PR TITLE
Update verb_으리라.yaml

### DIFF
--- a/point/verb_으리라.yaml
+++ b/point/verb_으리라.yaml
@@ -31,6 +31,14 @@ definitions:
         translated: The sun will rise soon.
         audio_url: https://r2.kimchi-reader.app/grammar/곧_해가_떠오르리라__2024-10-25.mp3
       - type: simple
+        sentence: 그 사람이 그런 짓을 하<f>리라</f>고는 상상도 못했어요. 
+        translated: I couldn't even imagine that he would do such a thing. 
+        audio_url: 
+      - type: simple
+        sentence: 자신은 그녀에게 아주 소중한 친구이리라는 자신감이 있었다. 
+        translated: He was confident that she considered him a precious friend.
+        audio_url: 
+      - type: simple
         sentence: 그녀가 성공하겠<f>으리라</f>.
         translated: She will probably succeed.
         audio_url: https://r2.kimchi-reader.app/grammar/그녀가_성공하겠으리라__2024-10-25.mp3


### PR DESCRIPTION
updated verb_으리라 to add 2 new sentences showing other ways that the grammar is used (preceding "는", preceding "고") that currently do not parse 