### PR TITLE
Added -(으)되

### DIFF
--- a/point/verb_으되.yaml
+++ b/point/verb_으되.yaml
@@ -1,0 +1,43 @@
+name: (으)되
+definitions:
+  - slug: but-however
+    name: But, however
+    english_alternatives: But, however, just
+    meaning: Introduces some truth but adds a contrasting fact, details, conditions, or restrictions.
+    examples:
+      - type: simple
+        sentence: 한국 드라마를 당연히 보시되 영어 자막만 쓰지 마셔요.
+        translated: Watch K-dramas, of course, just don't use English subtitles.
+      - type: simple
+        sentence: 돈은 있으되 쓸 시간은 없다...
+        translated: I have the money, but not the time to spend it...
+  - slug: archaic-quoting
+    name: Old-style quoting introduction
+    english_alternatives: Says/said so
+    meaning: Introduces a direct quote.
+    examples:
+      - type: simple
+        sentence: 임금님이 말씀하시되, "들라 하라!"
+        translated: The king said, "let him in!"
+metadata:
+  type: verb
+details: |-
+  # Usage {#usage}
+  
+  This grammar point is very formal, literary, or archaic and shows up in such texts or those mimicking their style.
+  
+  The old-style direct quote introduction meaning is only really used in archaic contexts like the Bible or old records.
+  
+  # Alternative forms {#alternative-forms}
+  
+  Regardless of whether the verb ends with a consonant or a vowel, the form -되 is used.
+  However, after 있다, 없다, -:grammar[verb_았_었_했]-, or -:grammar[verb_겠]-, the form -으되 is used.
+  In nonstandard writing though, some people may use -되 after those as well.
+  
+  In archaic speech, after :grammar[noun_이다] or 아니다, the form -로되 may be used.
+  
+  # Synonyms {#synonyms}
+  
+  The first meaning is similar to :grammar[verb_지만], :grammar[verb_ㄴ데_은데_는데], or -는 이상.
+  
+  The second meaning is similar to -기를 or -길.


### PR DESCRIPTION
This is kind of complicated because unlike other grammars with optional (으), this one only takes it after 있다, 없다, 겠 (supposition) and 았/었 (past tense). However 있되 and shit can be seen here and there so that shouldn't be excluded either.

Stuff like 먹으되 is wrong though. I don't know if Korean's use it or not though...