### PR TITLE
Deferential infix

### DIFF
--- a/point/으오_으옵_사오_사옵_자오_자옵.yaml
+++ b/point/으오_으옵_사오_사옵_자오_자옵.yaml
@@ -1,0 +1,40 @@
+point: (으)오/(으)옵/사오(ㅂ)/자오(ㅂ)
+definitions:
+  - slug: humility
+    name: Humility
+    meaning: Used to express humility and additional politeness in the 하소서체 speech level.
+    examples:
+      - type: simple
+        sentence: 그런 게 없으와.
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 당신을 믿사오니 힘내세요.
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 저희가 그 사람을 믿었삽더니.
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 저를 불러 주시옵소서.
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 스승의 뜻을 좇잡나이다.
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 
+        translated: 
+        audio_url:
+      - type: simple
+        sentence: 
+        translated: 
+        audio_url:
+metadata:
+  type: verb
+details: |-
+This differs from 시 in that 시 shows respect to the subject of the verb, while this shows politeness and
+humbleness from the speaker.
+  

--- a/point/으오_으옵_사오_사옵_자오_자옵.yaml
+++ b/point/으오_으옵_사오_사옵_자오_자옵.yaml
@@ -1,40 +1,46 @@
-point: (으)오/(으)옵/사오(ㅂ)/자오(ㅂ)
+point: (으)오/(으)옵/사오/사옵/자오/자옵
 definitions:
   - slug: humility
     name: Humility
-    meaning: Used to express humility and additional politeness in the 하소서체 speech level.
+    meaning: Used to express humility and additional politeness in the 하소서체 speech level. 사옵 and 자옵 are
+    occasionally shortened to 삽 and 잡 respectively.
     examples:
       - type: simple
-        sentence: 그런 게 없으와.
-        translated: 
+        sentence: 여기 그런 게 <f>없으와</f>.
+        translated: We don't have that here.
         audio_url:
       - type: simple
-        sentence: 당신을 믿사오니 힘내세요.
-        translated: 
+        sentence: 필요한 거 있으시다면 저를 불러 <f>주시옵소서</f>.
+        translated: Please call me if you need anything.
         audio_url:
       - type: simple
-        sentence: 저희가 그 사람을 믿었삽더니.
-        translated: 
+        sentence: 저희가 그 사람을 <f>믿었삽더니</f> 배신당했나이다.
+        translated: We trusted them, but they betrayed us.
         audio_url:
       - type: simple
-        sentence: 저를 불러 주시옵소서.
-        translated: 
+        sentence: 당신을 <f>믿사오니</f> 힘내세요.
+        translated: I believe in you, so cheer up.
         audio_url:
       - type: simple
-        sentence: 스승의 뜻을 좇잡나이다.
-        translated: 
+        sentence: 스승의 뜻을 <f>좇잡나이다</f>.
+        translated: I shall follow my teacher’s will.
         audio_url:
       - type: simple
-        sentence: 
-        translated: 
+        sentence: 당신을 <f>믿사옵고</f> <f>따르옵니다</f>.
+        translated: We trust in and follow you.
         audio_url:
       - type: simple
-        sentence: 
-        translated: 
+        sentence: 분부 <f>받자옵나이다</f>.
+        translated: We await your instructions.
         audio_url:
 metadata:
   type: verb
 details: |-
-This differs from 시 in that 시 shows respect to the subject of the verb, while this shows politeness and
-humbleness from the speaker.
+  # What is 하소서체? {#what-is-하소서체?}
+
+  <f>하소서체</f> is honorific speech used in archaic Korean; used to extremely respectfully address the listener. To modern 
+  Korean speakers this level of speech is perceived as an archaic style used only during the monarchical era. 
   
+  In modern Korean <f>하소서체</f> is functionally used only in literary expressions, and it is considered natural to use only
+  when addressing a deity. You will encounter <f>하소서체</f> in period dramas, traditional literature, the bible, prayers
+  to God, and similar.  :source[https://namu.wiki/w/하소서체]


### PR DESCRIPTION
I already sent you a list of all the naver examples to make test cases but to help you build the parsing rules, the usage rules as stated by naver dict are more or less as follows:

after the stem of a verb with a 받침 other than ㄹ or after 었 or 겠, & before ㄴㄹ ㅁ or other endings beginning with a vowel:  으오 
after the stem of a verb without a 받침 or after ㄹ or 으시, & before ㄴㄹ ㅁ or other endings beginning with a vowel:  오 

after the stem of a verb with a 받침 other than ㄹ or after 었 or 겠 & before other endings beginning with a consonant:  으옵 
after the stem of a verb without a 받침 or after ㄹ or 으시 & before other endings beginning with a consonant:  옵 

after the stem of a verb with a 받침 or after 었 or 겠 & before ㄴㄹ ㅁ or other endings beginning with a vowel:  사오
after the stem of a verb with a 받침 or after 었 or 겠 & before other endings beginning with a consonant:    삽, 사옵 

usually after the stem of a verb ending in ㄷ or ㅊ, and before ㄴㄹ ㅁ or other endings beginning with a vowel:  자오
usually after the stem of a verb ending in ㄷ or ㅊ, and  before other endings beginning with a consonant:   잡, 자옵