### PR TITLE
Add 읍니다/까 to 습니다.

### DIFF
--- a/point/verb_습니까_ㅂ니까.yaml
+++ b/point/verb_습니까_ㅂ니까.yaml
@@ -21,3 +21,7 @@ metadata:
   type: verb
 details: |-
   This is the interrogative form of :grammar[verb_습니다_ㅂ니다].
+
+  # Alternative forms {#alt-forms}
+
+  Much like :grammar[verb_습니다_ㅂ니다], the interrogative form also had an older form -읍니까 after final consonants ㅆ and ㅄ. See the declarative form for more.

--- a/point/verb_습니다_ㅂ니다.yaml
+++ b/point/verb_습니다_ㅂ니다.yaml
@@ -20,3 +20,12 @@ definitions:
 metadata:
   type: verb
 details: |-
+  # Alternative forms {#alt-forms}
+  
+  Before 1989, this grammar point was written as -읍니다 after final consonants ㅆ and ㅄ. For example:
+  ::example[제가 하겠읍니다! | I will do it]
+  ::example[선곡하신 곡이 없읍니다. | The song you've selected is unavailable]
+
+  This usage of -읍니다 can still be seen in the writings of older people or to give a piece of text the vibe that a person who learned Korean spelling before 1989 is writing it.
+  In modern usage, this form can sometimes be used humorously even after consonants that usually wouldn't take -읍니다. For example:
+  ::example[그렇읍니다! | It is so!]


### PR DESCRIPTION
Before 1989, -습니다 had an alternative written form -읍니다 primarily used after certain consonants (mainly ㅆ and ㅄ).

From the modern view, the consonant restriction no longer really exists, since when people try to mimic older speech they do so mistakenly (그렇읍니다, 고맙읍니다, etc).