### PR TITLE
Added -고프다 (contraction of -고 싶다)

### DIFF
--- a/point/verb_고프다.yaml
+++ b/point/verb_고프다.yaml
@@ -1,0 +1,22 @@
+name: 고프다
+definitions:
+  - slug: desire
+    name: Desire
+    english_alternatives: to want, desire
+    meaning: Used to express a desire or wish to do something. A shortened form of :grammar[고_싶다].
+    examples:
+      - sentence: 나도 춤추고파!
+        type: simple
+        translated: I want to dance too!
+      - sentence: 예전부터 보고픈 사람을 드디어 봤다.
+        type: simple
+        translated: I finally saw the person I've wanted to see for a long time.
+metadata:
+  type: verb
+details: |-
+  # Usage (#usage)
+
+  -고프다 as a contraction of -:grammar[고_싶다]{noprefix} is used in literary or poetic settings like novels, poems, or songs.
+  It's mostly seen in the noun modifier form as -고픈.
+
+  It's not to be confused with the adjective 고프다 (for one's stomach to be empty).

--- a/relation.yaml
+++ b/relation.yaml
@@ -111,6 +111,7 @@ relation:
       - { id: "verb_ㄴ데_은데_는데", slug: "background-information" }
   - concern:
       - { id: "고_싶다", slug: "desire" }
+      - { id: "verb_고프다", slug: "desire" }
       - { id: "었으면_좋겠다", slug: "person-wish-or-hope" }
   - concern:
       - { id: "ㄹ_수_있다", slug: "ability-or-possibility" }


### PR DESCRIPTION
Meaning and usage-wise identical to 고 싶다.

Goes directly on verb roots and conjugates exactly like the adjective 고프다.

먹다 -> 먹고프다 > 먹고픈 / 먹고파
하다 -> 하고프다 > 하고픈 / 하고파
etc.