### PR TITLE
Verb 거들랑 걸랑

### DIFF
--- a/inheritance.yaml
+++ b/inheritance.yaml
@@ -265,3 +265,5 @@ inheritance:
     children: ["verb_아도_어도_여도", "verb_지"]
   - parent: "후에"
     children: ["noun_에", "verb_ㄴ_은_는_ㄹ_을"]
+  - parent: "verb_거들랑_걸랑"
+    children: ["verb_거든"]

--- a/point/verb_거들랑_걸랑.yaml
+++ b/point/verb_거들랑_걸랑.yaml
@@ -1,0 +1,39 @@
+name: 거들랑/걸랑
+definitions:
+  - slug: informing
+    name: Informing
+    english_alternatives:
+    meaning: Indicates the speaker is revealing information the listener is likely unaware of.
+    examples:
+      - type: simple
+        sentence: 그 무렵 우리는 서울에서 살았거들랑.
+        translated: We were living in Seoul around then.
+        audio_url: 
+      - type: simple
+        sentence: 사실은 그 아이가 내 친구 동생이걸랑.
+        translated: Actually, that kid is my friend's younger sibling.
+        audio_url:         
+  - slug: conditional
+    name: Conditional
+    english_alternatives: if actually true, then
+    meaning: Expresses that if the preceding statement turns out to be true, then the following statement can happen.
+    examples:
+      - type: simple
+        sentence: 철수를 만나거들랑 내 말을 전해라.
+        translated: If you see Chul-soo, please give him my regards.
+        audio_url: 
+      - type: simple
+        sentence: 서울에 가거들랑 편지해라.
+        translated: Write me if you go to Seoul.
+        audio_url: 
+      - type: simple
+        sentence: 커피가 마시고 싶걸랑 설탕을 사 와라.
+        translated: If you want coffee, go buy some sugar.
+        audio_url: 
+metadata:
+  type: verb
+details: |-
+  # Usage {#usage}
+
+  :grammar[verb_거들랑_걸랑]{conditional} usually appears in the middle of the sentence while :grammar[verb_거들랑_걸랑]{informing}
+  is used at the end of the sentence.

--- a/relation.yaml
+++ b/relation.yaml
@@ -125,3 +125,9 @@ relation:
   - concern:
       - { id: "(으)ㄹ까 봐", slug: "concern-about-something" }
       - { id: "(으)ㄹ라", slug: "expresses-concern" }
+  - concern:
+      - { id: "verb_거들랑_걸랑", slug: "conditional" }
+      - { id: "verb_거든", slug: "conditional" }
+  - concern:
+      - { id: "verb_거들랑_걸랑", slug: "informing" }
+      - { id: "verb_거든", slug: "reasoning" }


### PR DESCRIPTION
This has an identical meaning to the current two meanings of 거든 listed on the kimchi grammar page (although there are more meanings of 거든 that are not shared with 거들랑). This is because 거들랑 is a combination of 거든 + 을랑 which is not implemented currently. So, I added inheritances and relations from 거든 to 거들랑 hope that's chill.