### PR TITLE
Create verb_나이까.yaml

### DIFF
--- a/point/verb_나이까.yaml
+++ b/point/verb_나이까.yaml
@@ -1,0 +1,28 @@
+point: 나이까
+definitions:
+  - slug: question
+    name: Question
+    meaning: Used to ask a question in the 하소서체 speech level.
+    examples:
+      - type: simple
+        sentence: 어찌 감히 어명을 거역하겠나이까?
+        translated: How could I possibly dare to disobey the royal command?
+        audio_url: 
+      - type: simple
+        sentence: 주인님, 부르셨나이까?
+        translated: Master, did you call me?
+        audio_url: 
+      - type: simple
+        sentence: 제가 어찌 그런 말을 하겠사옵나이까?
+        translated: How could I possibly say such a thing?
+        audio_url: 
+metadata:
+  type: verb
+details: |-
+  # What is 하소서체? {#what-is-하소서체?}
+
+  <f>하소서체</f> is honorific speech used in archaic Korean; used to extremely respectfully address the listener. To modern
+  Korean speakers this level of speech is perceived as an archaic style used only during the monarchical era.
+  In modern Korean <f>하소서체</f> is functionally used only in literary expressions, and it is considered natural to use only
+  when addressing a deity. You will encounter <f>하소서체</f> in period dramas, traditional literature, the bible, prayers
+  to God, and similar.  :source[https://namu.wiki/w/하소서체]


### PR DESCRIPTION
Dictionary says 나이까 can go after 있다, 없다, 계시다, action verbs, 으시, 었, 겠, and 사옵. So basically just it doesn't go after descriptive verbs ig? I didn't do relations for this one either but you might consider adding relations to other 하소서체 conjugations (나이다, 으오/사오/사옵/..., 소서, 소이까, etc), and/or other question conjugations, like 습니까.